### PR TITLE
Integrate YOLO-based feature filtering

### DIFF
--- a/include/Extractors/SPextractor.h
+++ b/include/Extractors/SPextractor.h
@@ -30,6 +30,7 @@
 #include <Eigen/Core>
 #include <opencv2/opencv.hpp>
 #include "Extractors/superpoint_onnx.h"
+#include "YoloDetection.h"
 //#include "Extractors/super_point.h"
 #ifdef EIGEN_MPL2_ONLY
 #undef EIGEN_MPL2_ONLY
@@ -101,6 +102,9 @@ public:
     std::string mModelstr = "onnx";//表明创建onnx模型还是tensorrt
 
     float lastmatchnum = 0;
+    void FilterDynamicKeypoints(const cv::Mat& image,
+                                std::vector<cv::KeyPoint>& keypoints,
+                                cv::Mat& descriptors);
 protected:
 
     void ComputePyramid(cv::Mat image);


### PR DESCRIPTION
## Summary
- include `YoloDetection.h` in the SuperPoint extractor
- initialize the detector when constructing `SPextractor`
- add `FilterDynamicKeypoints` helper to discard features on dynamic objects
- call the filter after SuperPoint inference in single and multi layer modes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68592b54b7c8832898804143040a8705